### PR TITLE
Subscription payment succeeded

### DIFF
--- a/djpaddle/mappers.py
+++ b/djpaddle/mappers.py
@@ -9,9 +9,15 @@ _cache.modules = {}
 
 def _get_fn(fn, *args, **kwargs):
     mod_name, func_name = fn.rsplit(".", 1)
-    if mod_name not in _cache.modules:
-        _cache.modules[mod_name] = importlib.import_module(mod_name)
-    return getattr(_cache.modules[mod_name], func_name)
+    try:
+        cached_modules = _cache.modules
+    except AttributeError:  # pragma: no cover
+        # AttributeError: '_thread._local' object has no attribute 'modules'
+        cached_modules = {}
+
+    if mod_name not in cached_modules:
+        cached_modules[mod_name] = importlib.import_module(mod_name)
+    return getattr(cached_modules[mod_name], func_name)
 
 
 def subscriber_by_payload(Subscriber, payload):

--- a/djpaddle/models.py
+++ b/djpaddle/models.py
@@ -170,7 +170,7 @@ class Subscription(PaddleBaseModel):
             data["subscriber"] = mappers.get_subscriber_by_payload(Subscriber, payload)
         except Subscriber.DoesNotExist:
             warning = "Subscriber could not be found for subscription {0} with payload {1}. Subscriber left empty."
-            log.warn(warning.format(data["id"], payload))
+            log.warning(warning.format(data["id"], payload))
             data["subscriber"] = None
 
         # transform `subscription_plan_id` to plan ref

--- a/djpaddle/models.py
+++ b/djpaddle/models.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 
 from django.db import models
+from django.conf import settings as djsettings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -10,7 +11,7 @@ from paddle import PaddleClient
 
 from . import settings, signals, mappers
 from .fields import PaddleCurrencyCodeField
-from .utils import PADDLE_DATETIME_FORMAT
+from .utils import PADDLE_DATETIME_FORMAT, PADDLE_DATE_FORMAT
 
 log = logging.getLogger("djpaddle")
 
@@ -191,6 +192,8 @@ class Subscription(PaddleBaseModel):
             if key in valid_field_names:
                 data[key] = value
 
+        data = convert_datetime_strings_to_datetimes(data, cls)
+
         return data
 
     @classmethod
@@ -202,9 +205,6 @@ class Subscription(PaddleBaseModel):
         except cls.DoesNotExist:
             return cls.objects.create(pk=pk, **data)
 
-        event_time = datetime.strptime(data["event_time"], PADDLE_DATETIME_FORMAT)
-        local_time_zone = timezone.get_default_timezone()
-        data["event_time"] = timezone.make_aware(event_time, local_time_zone)
         if subscription.event_time < data["event_time"]:
             cls.objects.filter(pk=pk).update(**data)
 
@@ -240,3 +240,23 @@ if settings.DJPADDLE_LINK_STALE_SUBSCRIPTIONS:
             queryset = Subscription.objects.filter(subscriber=None)
             queryset = mappers.get_subscriptions_by_subscriber(instance, queryset)
             queryset.update(subscriber=instance)
+
+
+def convert_datetime_strings_to_datetimes(data, model):
+    datetime_fields = [field.name for field in model._meta.get_fields() if isinstance(field, models.DateTimeField)]
+    for field in datetime_fields:
+        if field not in data:
+            continue
+
+        try:
+            data[field] = datetime.strptime(data[field], PADDLE_DATETIME_FORMAT)
+        except ValueError:
+            # Some fields such as next_bill_date should perhaps be
+            # a DateField not DatetimeField
+            data[field] = datetime.strptime(data[field], PADDLE_DATE_FORMAT)
+
+        if djsettings.USE_TZ:
+            local_time_zone = timezone.get_default_timezone()
+            data[field] = timezone.make_aware(data[field], local_time_zone)
+
+    return data

--- a/djpaddle/models.py
+++ b/djpaddle/models.py
@@ -228,6 +228,7 @@ class Checkout(models.Model):
 @receiver(signals.subscription_created)
 @receiver(signals.subscription_updated)
 @receiver(signals.subscription_cancelled)
+@receiver(signals.subscription_payment_succeeded)
 def subscription_event(sender, payload, *args, **kwargs):
     Subscription.create_or_update_by_payload(payload)
 

--- a/djpaddle/signals.py
+++ b/djpaddle/signals.py
@@ -1,28 +1,28 @@
 import django.dispatch
 
 # Subscription Alerts
-subscription_created = django.dispatch.Signal(providing_args=["payload"])
-subscription_updated = django.dispatch.Signal(providing_args=["payload"])
-subscription_cancelled = django.dispatch.Signal(providing_args=["payload"])
-subscription_payment_succeeded = django.dispatch.Signal(providing_args=["payload"])
-subscription_payment_failed = django.dispatch.Signal(providing_args=["payload"])
-subscription_payment_refunded = django.dispatch.Signal(providing_args=["payload"])
+subscription_created = django.dispatch.Signal()
+subscription_updated = django.dispatch.Signal()
+subscription_cancelled = django.dispatch.Signal()
+subscription_payment_succeeded = django.dispatch.Signal()
+subscription_payment_failed = django.dispatch.Signal()
+subscription_payment_refunded = django.dispatch.Signal()
 
 # One-off Purchases
-locker_processed = django.dispatch.Signal(providing_args=["payload"])
-payment_succeeded = django.dispatch.Signal(providing_args=["payload"])
-payment_refunded = django.dispatch.Signal(providing_args=["payload"])
+locker_processed = django.dispatch.Signal()
+payment_succeeded = django.dispatch.Signal()
+payment_refunded = django.dispatch.Signal()
 
 # Risk & Dispute Alerts
-payment_dispute_created = django.dispatch.Signal(providing_args=["payload"])
-payment_dispute_closed = django.dispatch.Signal(providing_args=["payload"])
-high_risk_transaction_created = django.dispatch.Signal(providing_args=["payload"])
-high_risk_transaction_updated = django.dispatch.Signal(providing_args=["payload"])
+payment_dispute_created = django.dispatch.Signal()
+payment_dispute_closed = django.dispatch.Signal()
+high_risk_transaction_created = django.dispatch.Signal()
+high_risk_transaction_updated = django.dispatch.Signal()
 
 # Payout Alerts
-transfer_created = django.dispatch.Signal(providing_args=["payload"])
-transfer_paid = django.dispatch.Signal(providing_args=["payload"])
+transfer_created = django.dispatch.Signal()
+transfer_paid = django.dispatch.Signal()
 
 # Audience Alerts
-new_audience_member = django.dispatch.Signal(providing_args=["payload"])
-update_audience_member = django.dispatch.Signal(providing_args=["payload"])
+new_audience_member = django.dispatch.Signal()
+update_audience_member = django.dispatch.Signal()

--- a/tests/test_mappers.py
+++ b/tests/test_mappers.py
@@ -13,6 +13,13 @@ class TestPaddleMappers(TestCase):
         with self.assertRaises(Subscriber.DoesNotExist):
             mappers.get_subscriber_by_payload(Subscriber, payload)
 
+    def test_get_subscriber_by_payload_missing_email(self):
+        Subscriber = settings.get_subscriber_model()
+        payload = {"not-email": "nonexistent@email.com"}
+
+        with self.assertRaises(Subscriber.DoesNotExist):
+            mappers.get_subscriber_by_payload(Subscriber, payload)
+
     def test_get_subscriptions_by_subscriber(self):
         Subscriber = settings.get_subscriber_model()
         subscriber = Subscriber.objects.create(username="user", email="test@example.com")


### PR DESCRIPTION
This pull request was originally intended just to add the below line to the `models.py`:

```python
@receiver(signals.subscription_created)
@receiver(signals.subscription_updated)
@receiver(signals.subscription_cancelled)
+ @receiver(signals.subscription_payment_succeeded)
def subscription_event(sender, payload, *args, **kwargs):
    Subscription.create_or_update_by_payload(payload)
```

But running tox I noticed quite a few warnings:

```
tests/test_webhooks.py::TestWebhook::test_subscription_cancelled_webhook 
dj-paddle/venv/lib/python3.6/site packages/django/db/models/fields/__init__.py:1370: RuntimeWarning: DateTimeField Subscription.event_time received a naive datetime (2020-05-20 23:37:36) while time zone support is active. RuntimeWarning)
```

```
tests/test_webhooks.py: 10 warnings
 dj-paddle/djpaddle/models.py:174: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead - log.warn(warning.format(data["id"], payload))
```

```
dj-paddle/djpaddle/signals.py:28: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
```

I also had an issue when using `runserver` where `threading.local(). modules` would not exist despite the fact it's been explicitly defined as an attribute when the mappers module is loaded. I've added a work-around but could test the error path as I couldn't replicate the issue when running the tests with `tox`.

Finally I noticed we were missing a small test when an email is missing for the subscriber payload so I added it.