### PR TITLE
Support for the Paddle sandbox environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,10 @@ Add your paddle keys and set the operating mode:
     # can be found at https://vendors.paddle.com/public-key
     DJPADDLE_PUBLIC_KEY = '<your-public-key>'
 
-djpaddle includes a ``vendor_id`` template context processor which adds your vendor ID as ``DJPADDLE_VENDOR_ID`` to each template context:
+    # More info at https://developer.paddle.com/getting-started/sandbox
+    DJPADDLE_SANDBOX = False
+
+djpaddle includes ``vendor_id`` and ``sandbox`` template context processors which adds your vendor ID as ``DJPADDLE_VENDOR_ID`` and if you want to use the sandbox as ``DJPADDLE_SANDBOX`` to each template context:
 
 .. code-block:: python
 
@@ -81,6 +84,7 @@ djpaddle includes a ``vendor_id`` template context processor which adds your ven
             'context_processors': [
                 ...
                 'djpaddle.context_processors.vendor_id',
+                'djpaddle.context_processors.sandbox',
                 ...
             ]
         }

--- a/djpaddle/context_processors.py
+++ b/djpaddle/context_processors.py
@@ -3,6 +3,14 @@ from . import settings
 
 def vendor_id(request):
     """
-    Return the paddle.com vendor ID as a context variables
+    Return the paddle.com vendor ID as a context variable
     """
     return {"DJPADDLE_VENDOR_ID": settings.DJPADDLE_VENDOR_ID}
+
+
+def sandbox(request):
+    """
+    Return whether to use the Paddle.com sandbox environment
+    as a context variable
+    """
+    return {"DJPADDLE_SANDBOX": settings.DJPADDLE_SANDBOX}

--- a/djpaddle/models.py
+++ b/djpaddle/models.py
@@ -15,7 +15,11 @@ from .utils import PADDLE_DATETIME_FORMAT, PADDLE_DATE_FORMAT
 
 log = logging.getLogger("djpaddle")
 
-paddle_client = PaddleClient(vendor_id=settings.DJPADDLE_VENDOR_ID, api_key=settings.DJPADDLE_API_KEY)
+paddle_client = PaddleClient(
+    vendor_id=settings.DJPADDLE_VENDOR_ID,
+    api_key=settings.DJPADDLE_API_KEY,
+    sandbox=settings.DJPADDLE_SANDBOX,
+)
 
 
 class PaddleBaseModel(models.Model):

--- a/djpaddle/settings.py
+++ b/djpaddle/settings.py
@@ -13,6 +13,11 @@ DJPADDLE_API_KEY = getattr(settings, "DJPADDLE_API_KEY")
 if not DJPADDLE_API_KEY:
     raise ImproperlyConfigured("'DJPADDLE_API_KEY' must be set")
 
+# More info at https://developer.paddle.com/getting-started/sandbox
+DJPADDLE_SANDBOX = getattr(settings, "DJPADDLE_SANDBOX", False)
+if not isinstance(DJPADDLE_SANDBOX, bool):
+    raise ImproperlyConfigured("'DJPADDLE_SANDBOX' must be a boolean")
+
 # can be found at https://vendors.paddle.com/public-key
 DJPADDLE_PUBLIC_KEY = getattr(settings, "DJPADDLE_PUBLIC_KEY")
 if not DJPADDLE_PUBLIC_KEY:

--- a/djpaddle/templates/djpaddle_paddlejs.html
+++ b/djpaddle/templates/djpaddle_paddlejs.html
@@ -1,5 +1,8 @@
 <script src="https://cdn.paddle.com/paddle/paddle.js"></script>
 <script type="text/javascript">
+{% if DJPADDLE_SANDBOX %}
+Paddle.Environment.set('sandbox');
+{% endif %}
 Paddle.Setup({
     vendor:  {{ DJPADDLE_VENDOR_ID }},
     {% if debug %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     django>=2.1
     pycryptodome>=3.9.4
     phpserialize>=1.3
-    paddle-client>=0.6.0
+    paddle-client>=1.0.0
 
 [options.packages.find]
 exclude =

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -13,3 +13,11 @@ class TestContextProcessors(TestCase):
             "DJPADDLE_VENDOR_ID": settings.DJPADDLE_VENDOR_ID,
         }
         self.assertDictEqual(expected_result, result)
+
+    def test_context_processor_sandbox(self):
+        sandbox = getattr(settings, "DJPADDLE_SANDBOX", False)
+        result = context_processors.sandbox(HttpRequest())
+        expected_result = {
+            "DJPADDLE_SANDBOX": sandbox,
+        }
+        self.assertDictEqual(expected_result, result)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,6 +38,25 @@ def test_invalid_djpaddle_public_key(settings):
         reload(settings)
 
 
+def test_missing_sandbox(settings):
+    from djpaddle import settings
+    from importlib import reload
+
+    reload(settings)
+    from djpaddle.settings import DJPADDLE_SANDBOX
+    assert DJPADDLE_SANDBOX is False
+
+
+def test_invalid_sandbox(settings):
+    settings.DJPADDLE_SANDBOX = 'NOT-TRUE-OR-FALSE'
+    from djpaddle import settings
+    from importlib import reload
+
+    with pytest.raises(ImproperlyConfigured) as error:
+        reload(settings)
+    assert error.match("'DJPADDLE_SANDBOX' must be a boolean")
+
+
 def test_djpaddle_subscriber_model_invalid_name(settings):
     settings.DJPADDLE_SUBSCRIBER_MODEL = "fakemodel"
     from djpaddle import settings

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,8 +7,9 @@ def test_missing_djpaddle_vendor_id(settings):
     from djpaddle import settings
     from importlib import reload
 
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ImproperlyConfigured) as error:
         reload(settings)
+    assert error.match("'DJPADDLE_VENDOR_ID' must be set")
 
 
 def test_missing_djpaddle_api_key(settings):
@@ -16,8 +17,9 @@ def test_missing_djpaddle_api_key(settings):
     from djpaddle import settings
     from importlib import reload
 
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ImproperlyConfigured) as error:
         reload(settings)
+    assert error.match("'DJPADDLE_API_KEY' must be set")
 
 
 def test_missing_djpaddle_public_key(settings):
@@ -25,17 +27,23 @@ def test_missing_djpaddle_public_key(settings):
     from djpaddle import settings
     from importlib import reload
 
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ImproperlyConfigured) as error:
         reload(settings)
+    assert error.match("'DJPADDLE_PUBLIC_KEY' must be set")
 
 
 def test_invalid_djpaddle_public_key(settings):
-    settings.DJPADDLE_PUBLIC_KEY = 123
+    settings.DJPADDLE_PUBLIC_KEY = "123"
     from djpaddle import settings
     from importlib import reload
 
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ImproperlyConfigured) as error:
         reload(settings)
+    message = (
+        "failed to convert 'DJPADDLE_PUBLIC_KEY'; original message: RSA key "
+        "format is not supported"
+    )
+    assert error.match(message)
 
 
 def test_missing_sandbox(settings):
@@ -65,8 +73,12 @@ def test_djpaddle_subscriber_model_invalid_name(settings):
     reload(settings)
     from djpaddle.settings import get_subscriber_model
 
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ImproperlyConfigured) as error:
         get_subscriber_model()
+    message = (
+        "DJPADDLE_SUBSCRIBER_MODEL must be of the form 'app_label.model_name'."
+    )
+    assert error.match(message)
 
 
 def test_djpaddle_subscriber_model_does_not_exist(settings):
@@ -77,5 +89,10 @@ def test_djpaddle_subscriber_model_does_not_exist(settings):
     reload(settings)
     from djpaddle.settings import get_subscriber_model
 
-    with pytest.raises(ImproperlyConfigured):
+    with pytest.raises(ImproperlyConfigured) as error:
         get_subscriber_model()
+    message = (
+        "DJPADDLE_SUBSCRIBER_MODEL refers to model '{}' "
+        "that has not been installed."
+    )
+    assert error.match(message.format(settings.DJPADDLE_SUBSCRIBER_MODEL))

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ whitelist_externals = make
 commands = make html
 deps =
     django>=2.1
-    paddle-python>=0.5.1
+    paddle-client>=1.0.0
     sphinx
     sphinx_rtd_theme
     sphinx-autobuild


### PR DESCRIPTION
Paddle have recently added a sandbox environment for development and testing - https://developer.paddle.com/getting-started/sandbox

The Paddle Client (1.0.0) now supports the sandbox environment (https://github.com/paddle-python/paddle-client/pull/6) and since all of the requests to Paddle use the Paddle Client it's pretty trivial for us to support it here as well.
I have no updated any of the tests etc for now as I believed most of them are mocked anyway.

I also noticed the settings tests didn't actually check the error message that was raised to ensure it's correct so I added checks for that.
