### PR TITLE
Add sandbox info to the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,8 @@ Next add a Paddle product or subscription plan into the page context. Below is a
             context['paddle_plan'] = Plan.objects.get(pk=kwargs['plan_id'])
             # If you have not added 'djpaddle.context_processors.vendor_id' as a template context processors
             context['DJPADDLE_VENDOR_ID'] = settings.DJPADDLE_VENDOR_ID
+            # If you have not added 'djpaddle.context_processors.sandbox' as a template context processors
+            context['DJPADDLE_SANDBOX'] = settings.DJPADDLE_SANDBOX
             return context
 
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -44,8 +44,11 @@ Add your paddle keys and set the operating mode:
     # can be found at https://vendors.paddle.com/public-key
     DJPADDLE_PUBLIC_KEY = '<your-public-key>'
 
+    # More info at https://developer.paddle.com/getting-started/sandbox
+    DJPADDLE_SANDBOX = False
 
-djpaddle includes ``vendor_id`` template context processor which adds your vendor ID as ``DJPADDLE_VENDOR_ID`` to each template context
+
+djpaddle includes ``vendor_id`` and ``sandbox`` template context processors which adds your vendor ID as ``DJPADDLE_VENDOR_ID`` and if you want to use the sandbox as ``DJPADDLE_SANDBOX`` to each template context
 
 .. code-block:: python
 
@@ -57,6 +60,7 @@ djpaddle includes ``vendor_id`` template context processor which adds your vendo
             'context_processors': [
                 ...
                 'djpaddle.context_processors.vendor_id',
+                'djpaddle.context_processors.sandbox',
                 ...
             ]
         }
@@ -100,6 +104,8 @@ Next add a Paddle product or subscription plan into the page context. Below is a
             context['paddle_plan'] = Plan.objects.get(pk=kwargs['plan_id'])
             # If you have not added 'djpaddle.context_processors.vendor_id' as a template context processors
             context['DJPADDLE_VENDOR_ID'] = settings.DJPADDLE_VENDOR_ID
+            # If you have not added 'djpaddle.context_processors.sandbox' as a template context processors
+            context['DJPADDLE_SANDBOX'] = settings.DJPADDLE_SANDBOX
 
             return context
 

--- a/docs/paddle_checkout.rst
+++ b/docs/paddle_checkout.rst
@@ -15,12 +15,18 @@ To use `Paddle checkout <https://developer.paddle.com/guides/how-tos/checkout/pa
 .. note::
     You need to have added the ``djpaddle.context_processors.vendor_id`` template context processor or manually add ``DJPADDLE_VENDOR_ID`` to your context.
 
+.. note::
+    This template also supports the `Paddle sandbox environment  <https://developer.paddle.com/getting-started/sandbox>`_ if you have added the``djpaddle.context_processors.sandbox`` template context processor or manually add ``DJPADDLE_SANDBOX`` to your context.
+
 If you want to customise the Paddle setup you can manually add PaddleJS and ``Paddle.Setup`` manually with:
 
 .. code-block:: html
 
     <script src="https://cdn.paddle.com/paddle/paddle.js"></script>
     <script type="text/javascript">
+    {% if DJPADDLE_SANDBOX %}
+    Paddle.Environment.set('sandbox');
+    {% endif %}
     Paddle.Setup({
         vendor:  {{ DJPADDLE_VENDOR_ID }},
     });


### PR DESCRIPTION
I had edited both `getting_started.rst` and  `paddle_checkout.rst`  within `docs/_build/_html/_sources/` instead of the actual docs and then not noticed I wasn't able to commit them. I need to remember to wipe the `docs/_build/` directory,

I had also missed a note to passing `DJPADDLE_SANDBOX` to the context in `README.rst`

A couple of quick questions:
* Do the docs build automatically on Read The Docs?
* How do we release a new version to PyPI?